### PR TITLE
Replace namespaces when destination is core

### DIFF
--- a/src/Command/MakeToCommand.php
+++ b/src/Command/MakeToCommand.php
@@ -286,7 +286,15 @@ class MakeToCommand extends Command implements SignalableCommandInterface
         }
 
         $sourceNS = $this->getNamespaces($this->rootPath.'composer.json');
-        $destNS = $this->getNamespaces($destinationJsonPath);
+
+        if (!$this->destinationModule) {
+            $destNS = [
+                'autoload' => 'PrestaShop\\PrestaShop\\',
+                'autoload-dev' => 'Tests\\',
+            ];
+        } else {
+            $destNS = $this->getNamespaces($destinationJsonPath);
+        }
 
         $replacePairs = [];
 
@@ -327,13 +335,6 @@ class MakeToCommand extends Command implements SignalableCommandInterface
      */
     private function getNamespaces(string $composerJsonPathname): array
     {
-        if (!$this->destinationModule) {
-            return [
-                'autoload' => 'PrestaShop\\PrestaShop\\',
-                'autoload-dev' => 'Tests\\',
-            ];
-        }
-
         $namespaces = [
             'autoload' => null,
             'autoload-dev' => null,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project! 

Please take the time to edit the "Answers" rows below with the necessary information.

You should check out PrestaShop contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Replace namespaces when destination is core.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10.
| How to test?  | Run a maker without specifying destination module and checks that namespaces are PrestaShop core ones.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
