### PR TITLE
Fix automatic destination module option adding

### DIFF
--- a/src/Command/MakeToCommand.php
+++ b/src/Command/MakeToCommand.php
@@ -224,7 +224,9 @@ class MakeToCommand extends Command implements SignalableCommandInterface
             $this->io->newLine();
             $this->io->section("Execution of $makeCommand");
 
-            $command = "php bin/console $makeCommand".($this->destinationModule ? " -m {$this->destinationModule}" : '');
+            $shouldAddDestinationModuleOption = $this->destinationModule && 1 === preg_match('/.*(prestashop|ps).*/', $makeCommand);
+
+            $command = "php bin/console $makeCommand".($shouldAddDestinationModuleOption ? " -m {$this->destinationModule}" : '');
 
             try {
                 if (!$this->isWindows()) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the project! 

Please take the time to edit the "Answers" rows below with the necessary information.

You should check out PrestaShop contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Description module option must be added to make command only if it is a custom one, dedicated to PrestaShop projects.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A.
| How to test?  | Run make-to command with a Symfony maker and with destination module option.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
